### PR TITLE
Refine trade penalties and add holding cost option

### DIFF
--- a/nas_rl_trader.py
+++ b/nas_rl_trader.py
@@ -34,6 +34,7 @@ class Args:
     reward: str
     patience: int
     trade_penalty_bps: float
+    holding_cost_bps: float
 
 
 
@@ -226,6 +227,7 @@ class SingleAssetEnv:
         hold_bonus_bps: float = 0.0,
         reward_mode: str = "return",
         trade_penalty_bps: float = 0.0,
+        holding_cost_bps: float = 0.0,
 
     ):
         self.features = features
@@ -240,6 +242,7 @@ class SingleAssetEnv:
 
         self.hold_bonus_bps = hold_bonus_bps / 10000.0
         self.trade_penalty = trade_penalty_bps / 10000.0
+        self.holding_cost = holding_cost_bps / 10000.0
 
         self.n_features = features.shape[1]
         self.state_dim = window_size * self.n_features + 2  # + position, cash_norm
@@ -320,7 +323,10 @@ class SingleAssetEnv:
             reward += self.hold_bonus_bps * prev_portfolio
 
         if delta_shares != 0 and self.trade_penalty > 0:
-            reward -= self.trade_penalty * prev_portfolio
+            reward -= self.trade_penalty * abs(delta_shares) * ask
+
+        if self.shares > 0 and self.holding_cost > 0:
+            reward -= self.holding_cost * prev_portfolio
 
         trade_info = {
             "timestamp": timestamp,
@@ -492,6 +498,7 @@ def build_env(df: pd.DataFrame, features: np.ndarray, args: Args) -> SingleAsset
         hold_bonus_bps=args.hold_bonus_bps,
         reward_mode=args.reward,
         trade_penalty_bps=args.trade_penalty_bps,
+        holding_cost_bps=args.holding_cost_bps,
     )
 
 
@@ -681,7 +688,7 @@ def parse_args() -> Args:
     parser.add_argument("--episodes", type=int, default=2000)
 
     parser.add_argument("--metric", choices=["end_value", "sharpe", "pnl_dd"], default="pnl_dd")
-    parser.add_argument("--hold_bonus_bps", type=float, default=0.0)
+    parser.add_argument("--hold_bonus_bps", type=float, default=2.0)
     parser.add_argument("--epsilon", type=float, default=1.0)
     parser.add_argument("--epsilon_min", type=float, default=0.01)
     parser.add_argument("--epsilon_decay", type=float, default=0.99)
@@ -690,6 +697,7 @@ def parse_args() -> Args:
     parser.add_argument("--reward", choices=["delta", "return"], default="return")
     parser.add_argument("--patience", type=int, default=50)
     parser.add_argument("--trade_penalty_bps", type=float, default=5.0)
+    parser.add_argument("--holding_cost_bps", type=float, default=0.0)
 
     args = parser.parse_args()
     return Args(**vars(args))


### PR DESCRIPTION
## Summary
- make trade penalty proportional to trade size rather than full portfolio
- add configurable holding cost and raise default hold bonus to encourage trending positions

## Testing
- `ruff check .` *(fails: linear_rl_trader.py:8:8 `re` imported but unused; personal_linear_rl_trader.py:8:8 `re` imported but unused)*
- `PYTHONWARNINGS=error pytest -q`
- `python linear_rl_trader.py --episodes 1 --seed 42` *(fails: the following arguments are required: -m/--mode)*


------
https://chatgpt.com/codex/tasks/task_e_68b5dc38dbb88323a55165345b2f1c75